### PR TITLE
Add file dialog to select RobloxStudioBeta.exe

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Threading;
+using System.Windows.Forms;
+using System.Linq;
 
 
 // I apologize for the horrible code.
@@ -14,6 +16,7 @@ namespace StudioPatcher2
 
         [DllImport("msvcrt")] static extern int _getch();
         [DllImport("crtdll.dll")] public static extern int _kbhit();
+        [STAThread]
         static void Main(string[] args)
         {
             Console.WriteLine(@"
@@ -26,24 +29,25 @@ namespace StudioPatcher2
                                                                       
                                                                       
         ");
-            Console.WriteLine("Please Drag & Drop RobloxStudioBeta.exe onto this window.");
-            var list = new List<String>();
-            for (int ch = _getch(); ch != '\r'; ch = _getch())
-            {
-                string file_name = "";
-                if (Convert.ToChar(ch) == '\"')
-                {
-                    while (Convert.ToChar(ch = _getch()) != '\"') file_name += Convert.ToChar(ch);
-                }
-                else
-                {
-                    file_name += Convert.ToChar(ch);
-                    while (_kbhit() != 0) file_name += Convert.ToChar(_getch());
-                }
-                list.Add(file_name);
-                Console.WriteLine("Loaded .exe, Press Enter to continue!");
+            Console.WriteLine("Please select RobloxStudioBeta.exe.");
 
-            }
+            // Gets the path with RobloxStudioBeta.exe in it
+            string appDataFolderPath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            string versionsFolderPath = Path.Combine(appDataFolderPath, "Roblox", "Versions");
+            var versionsDir = Directory.GetDirectories(versionsFolderPath);
+            string targetDir = versionsDir.FirstOrDefault(dir => File.Exists(Path.Combine(dir, "RobloxStudioBeta.exe")));
+
+            // Prompt the user to select a file from the target directory
+            var dialog = new OpenFileDialog();
+            dialog.InitialDirectory = targetDir;
+            dialog.Filter = "Roblox Studio|RobloxStudioBeta.exe";
+            dialog.Title = "Select RobloxStudioBeta.exe";
+            dialog.ShowDialog();
+
+            // Load the .exe into a list
+            var list = new List<string> { dialog.FileName };
+            Console.WriteLine("Loaded .exe, Press Enter to continue!");
+
             foreach (string item in list)
             {
                 string fileName = Path.GetFileName(item);

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 Enables the loading of custom themes into Roblox Studio.
 
+![StudioPatcher2](https://user-images.githubusercontent.com/80087248/236652960-d87e7c99-71d7-483d-8067-d92f7a8a703d.png)
+
 ## Usage
 
 ### GitHub
@@ -16,11 +18,13 @@ Enables the loading of custom themes into Roblox Studio.
 
 4. Once you have finished changing theme files, navigate back and double-click `StudioPatcher2.exe` to launch it, a terminal should open (A [false positive](#false-positives) might appear when you open `StudioPatcher2.exe`; you can click <kbd>More info</kbd> > <kbd>Run anyway</kbd>)
 
-5. Locate `RobloxStudioBeta.exe`, which should be located around `%APPDATA%\..\Local\Roblox\Versions\version-VERSION_NUMBER_HERE\RobloxStudioBeta.exe` and drag it into the terminal window
+5. In the file dialog window, select `RobloxStudioBeta.exe` and click <kbd>Open</kbd> to load the file
 
-6. Press <kbd>Enter</kbd> and wait for the patching process to finish
+6. Press <kbd>Enter</kbd> on your keyboard and wait for the patching process to finish.
 
-7. Launch `RobloxStudioPatched.exe`, which should be in the same path as `RobloxStudioBeta.exe`, and enjoy your custom themes (If the patch is in the `Release` folder, you need manually move it to the same path as `RobloxStudioBeta.exe`)
+5. When the patching is finished a confirmation should appear, you can press <kbd>Enter</kbd> on your keyboard to safely exit the patcher
+
+7. Launch `RobloxStudioPatched.exe`, which should be in the same path as `RobloxStudioBeta.exe` and enjoy your custom themes
 
 ## False Positives
 


### PR DESCRIPTION
Improves UX by adding a file picker instead of the user needing to access the file explorer and navigating to where RobloxStudioBeta.exe is located.

Adds a file dialog which will automatically locate a directory with any files named RobloxStudioBeta.exe and open in it. I would make detecting RobloxStudioBeta.exe automatic but they could be issues with having two directories with RobloxStudioBeta.exe in each which would create problems.

Updates README.md to show new installation steps along with a screenshot of StudioPatcher2.exe's terminal.

![StudioPatcher2.exe](https://user-images.githubusercontent.com/80087248/236653154-83aed4b2-5aab-4ea3-94f3-2b63303e2a08.png)