### PR TITLE
Open file explorer and close console

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -110,6 +110,10 @@ namespace StudioPatcher2
                         string patchedFilePath = Path.Combine(originalDirectory, "RobloxStudioPatched.exe");
                         File.WriteAllBytes(patchedFilePath, byt);
                         Console.WriteLine("File has been saved to " + originalDirectory);
+
+                        // Open file explorer with patched file selected and close console
+                        System.Diagnostics.Process.Start("explorer.exe", "/select, \"" + patchedFilePath + "\"");
+                        Environment.Exit(0);
                     }
 
                 }


### PR DESCRIPTION
Open file explorer and close console when it is done patching, so we don't have to navigate to the directory of RobloxStudioPatched.exe when we are done patching. 

This kind of makes the last few lines for pressing a key to close useless which are only used now when the file explorer is closed without selecting the correct file.